### PR TITLE
infra: bump cache to get latest deps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,13 +12,13 @@ commands:
           path: ~/repo
       - restore_cache:
           name: Restore node_modules cache
-          key: all-contributors-cli-{{ checksum "package.json" }}-{{ .Branch }}
+          key: all-contributors-cli-v2-{{ checksum "package.json" }}-{{ .Branch }}
   save_env_cache:
     description: Saves environment cache
     steps:
       - save_cache:
           name: Save node_modules cache
-          key: all-contributors-cli-{{ checksum "package.json" }}-{{ .Branch }}
+          key: all-contributors-cli-v2-{{ checksum "package.json" }}-{{ .Branch }}
           paths:
             - node_modules/
 


### PR DESCRIPTION
We should consider using a lockfile to prevent this related to the breaking change in: https://github.com/kentcdodds/eslint-config-kentcdodds/issues/25, fix in #150 also needs cache busted