### PR TITLE
feat(contribution-types): added `business` and `content`

### DIFF
--- a/src/util/contribution-types.js
+++ b/src/util/contribution-types.js
@@ -12,10 +12,18 @@ const defaultTypes = function(repoType) {
       description: 'Bug reports',
       link: repo.getLinkToIssues(repoType),
     },
+    business: {
+      symbol: '💼',
+      description: 'Business development',
+    },
     code: {
       symbol: '💻',
       description: 'Code',
       link: repo.getLinkToCommits(repoType),
+    },
+    content: {
+      symbol: '🖋',
+      description: 'Content',
     },
     design: {
       symbol: '🎨',


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
I added the missing types for "Business development" and "Content".

<!-- Why are these changes necessary? -->
**Why**:
Because they are specified in [the list](https://all-contributors.js.org/docs/emoji-key#table) but not supported by neither the CLI (until this PR is merged) nor the bot (incoming PR).

<!-- How were these changes implemented? -->
**How**:
By adding `business` and `content` to the list.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
