### PR TITLE
fix: default commitConvention to 'none'

### DIFF
--- a/src/util/config-file.js
+++ b/src/util/config-file.js
@@ -8,10 +8,17 @@ function readConfig(configPath) {
     if (!('repoType' in config)) {
       config.repoType = 'github'
     }
+    if (!('commitConvention' in config)) {
+      config.commitConvention = 'none'
+    }
     return config
   } catch (error) {
     if (error instanceof SyntaxError) {
-      throw new SyntaxError(`Configuration file has malformed JSON: ${configPath}. Error:: ${error.message}`)
+      throw new SyntaxError(
+        `Configuration file has malformed JSON: ${configPath}. Error:: ${
+          error.message
+        }`,
+      )
     }
     if (error.code === 'ENOENT') {
       throw new Error(`Configuration file not found: ${configPath}`)


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
Default `config.commitConvention` to `none`.

<!-- Why are these changes necessary? -->
At the moment, `config.commitConvention` only defaults to `none` during the configuration generation. If the configuration has been generated using an older version of `all-contributors-cli`, that value will be `undefined`. This eventually leads [the following line](https://github.com/all-contributors/all-contributors-cli/blob/2376ada660965e576fb81e788071ee32b7309947/src/util/git.js#L67) to crash with `Cannot read property 'msg' of undefined`. That line is triggered when adding new contributors.

<!-- How were these changes implemented? -->
When the configuration file is read, if `commitConvention` is `undefined`, it is set to `none`.

<!-- Have you done all of these things?  -->
**Checklist**:
- [ ] Documentation: N/A
- [ ] Tests: N/A
- [x] Ready to be merged
- [ ] Added myself to contributors table