### PR TITLE
fix: badge link change

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -325,6 +325,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "rachelcarmena",
+      "name": "Rachel M. Carmena",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/22792183?v=4",
+      "profile": "https://rachelcarmena.github.io",
+      "contributions": [
+        "code"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
 [![Code Coverage](https://img.shields.io/codecov/c/github/all-contributors/all-contributors-cli.svg)](https://codecov.io/github/all-contributors/all-contributors-cli)
 [![Version](https://img.shields.io/npm/v/all-contributors-cli.svg)](https://www.npmjs.com/package/all-contributors-cli)
 [![Downloads](https://img.shields.io/npm/dm/all-contributors-cli.svg)](http://www.npmtrends.com/all-contributors-cli)
-[![All Contributors](https://img.shields.io/badge/all_contributors-33-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-34-orange.svg?style=flat-square)](#contributors-)
 [![Star on Github](https://img.shields.io/github/stars/all-contributors/all-contributors-cli.svg?style=social)](https://github.com/all-contributors/all-contributors-cli/stargazers)
 
 ## The problem
@@ -64,7 +64,7 @@ specification for your GitHub or GitLab repository.
 
 If you're looking to use the cli, head over to [the cli docs on allcontributors.org](https://allcontributors.org/docs/en/cli/overview). The all-contributors website contains all the information required to install, configure and use the all-contributors-cli.
 
-## Contributors
+## Contributors ✨
 
 Thanks goes to these wonderful people
 ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
@@ -117,6 +117,7 @@ Thanks goes to these wonderful people
     <td align="center"><a href="https://github.com/nschonni"><img src="https://avatars2.githubusercontent.com/u/1297909?v=4" width="100px;" alt="Nick Schonning"/><br /><sub><b>Nick Schonning</b></sub></a><br /><a href="https://github.com/all-contributors/all-contributors-cli/commits?author=nschonni" title="Code">💻</a></td>
     <td align="center"><a href="https://cezaraugusto.net/"><img src="https://avatars0.githubusercontent.com/u/4672033?v=4" width="100px;" alt="Cezar Augusto"/><br /><sub><b>Cezar Augusto</b></sub></a><br /><a href="https://github.com/all-contributors/all-contributors-cli/commits?author=cezaraugusto" title="Documentation">📖</a></td>
     <td align="center"><a href="https://reinhold.is"><img src="https://avatars1.githubusercontent.com/u/5678122?v=4" width="100px;" alt="Jeppe Reinhold"/><br /><sub><b>Jeppe Reinhold</b></sub></a><br /><a href="https://github.com/all-contributors/all-contributors-cli/commits?author=JReinhold" title="Code">💻</a></td>
+    <td align="center"><a href="https://rachelcarmena.github.io"><img src="https://avatars0.githubusercontent.com/u/22792183?v=4" width="100px;" alt="Rachel M. Carmena"/><br /><sub><b>Rachel M. Carmena</b></sub></a><br /><a href="https://github.com/all-contributors/all-contributors-cli/commits?author=rachelcarmena" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/src/generate/__tests__/format-badge.js
+++ b/src/generate/__tests__/format-badge.js
@@ -4,9 +4,9 @@ import formatBadge from '../format-badge'
 test('return badge with the number of contributors', () => {
   const options = {}
   const expected8 =
-    '[![All Contributors](https://img.shields.io/badge/all_contributors-8-orange.svg?style=flat-square)](#contributors)'
+    '[![All Contributors](https://img.shields.io/badge/all_contributors-8-orange.svg?style=flat-square)](#contributors-)'
   const expected16 =
-    '[![All Contributors](https://img.shields.io/badge/all_contributors-16-orange.svg?style=flat-square)](#contributors)'
+    '[![All Contributors](https://img.shields.io/badge/all_contributors-16-orange.svg?style=flat-square)](#contributors-)'
 
   expect(formatBadge(options, _.times(_.constant({}), 8))).toBe(expected8)
   expect(formatBadge(options, _.times(_.constant({}), 16))).toBe(expected16)

--- a/src/generate/__tests__/index.js
+++ b/src/generate/__tests__/index.js
@@ -143,7 +143,7 @@ test('replace all-contributors badge if present', () => {
     'Badges',
     [
       '[![version](https://img.shields.io/npm/v/all-contributors-cli.svg?style=flat-square)](http://npm.im/all-contributors-cli)',
-      '[![All Contributors](https://img.shields.io/badge/all_contributors-0-orange.svg?style=flat-square)](#contributors)',
+      '[![All Contributors](https://img.shields.io/badge/all_contributors-0-orange.svg?style=flat-square)](#contributors-)',
       '[![version](https://img.shields.io/npm/v/all-contributors-cli.svg?style=flat-square)](http://npm.im/all-contributors-cli)',
     ].join(''),
     '',
@@ -155,7 +155,7 @@ test('replace all-contributors badge if present', () => {
     'Badges',
     [
       '[![version](https://img.shields.io/npm/v/all-contributors-cli.svg?style=flat-square)](http://npm.im/all-contributors-cli)',
-      '[![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors)',
+      '[![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors-)',
       '[![version](https://img.shields.io/npm/v/all-contributors-cli.svg?style=flat-square)](http://npm.im/all-contributors-cli)',
     ].join(''),
     '',

--- a/src/generate/format-badge.js
+++ b/src/generate/format-badge.js
@@ -1,7 +1,7 @@
 const _ = require('lodash/fp')
 
 const defaultTemplate =
-  '[![All Contributors](https://img.shields.io/badge/all_contributors-<%= contributors.length %>-orange.svg?style=flat-square)](#contributors)'
+  '[![All Contributors](https://img.shields.io/badge/all_contributors-<%= contributors.length %>-orange.svg?style=flat-square)](#contributors-)'
 
 module.exports = function formatBadge(options, contributors) {
   return _.template(options.badgeTemplate || defaultTemplate)({

--- a/src/generate/index.js
+++ b/src/generate/index.js
@@ -2,7 +2,7 @@ const _ = require('lodash/fp')
 const formatBadge = require('./format-badge')
 const formatContributor = require('./format-contributor')
 
-const badgeRegex = /\[!\[All Contributors\]\([a-zA-Z0-9\-./_:?=]+\)\]\(#\w+\)/
+const badgeRegex = /\[!\[All Contributors\]\([a-zA-Z0-9\-./_:?=]+\)\]\(#[\w-]+\)/
 
 function injectListBetweenTags(newContent) {
   return function(previousContent) {

--- a/src/init/__tests__/add-badge.js
+++ b/src/init/__tests__/add-badge.js
@@ -4,7 +4,7 @@ test('insert badge under title', () => {
   const content = ['# project', '', 'Description', '', 'Foo bar'].join('\n')
   const expected = [
     '# project',
-    '[![All Contributors](https://img.shields.io/badge/all_contributors-0-orange.svg?style=flat-square)](#contributors)',
+    '[![All Contributors](https://img.shields.io/badge/all_contributors-0-orange.svg?style=flat-square)](#contributors-)',
     '',
     'Description',
     '',
@@ -20,7 +20,7 @@ test('add badge if content is empty', () => {
   const content = ''
   const expected = [
     '',
-    '[![All Contributors](https://img.shields.io/badge/all_contributors-0-orange.svg?style=flat-square)](#contributors)',
+    '[![All Contributors](https://img.shields.io/badge/all_contributors-0-orange.svg?style=flat-square)](#contributors-)',
   ].join('\n')
 
   const result = addBadge(content)

--- a/src/init/init-content.js
+++ b/src/init/init-content.js
@@ -2,7 +2,7 @@ const _ = require('lodash/fp')
 const injectContentBetween = require('../util').markdown.injectContentBetween
 
 const badgeContent =
-  '[![All Contributors](https://img.shields.io/badge/all_contributors-0-orange.svg?style=flat-square)](#contributors)'
+  '[![All Contributors](https://img.shields.io/badge/all_contributors-0-orange.svg?style=flat-square)](#contributors-)'
 const headerContent =
   'Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):'
 const listContent = [


### PR DESCRIPTION
**What**: Badge links to the Contributors section now.

**Why**: Reported in issue #195 

**How**:
1. Run tests :green_heart: 
2. Change tests to consider `#contributors-` as the link
3. Run tests :red_circle: 
4. Fix code to pass the tests: initial badge content and regular expressions.
5. Run tests :green_heart: 
6. I updated README.md as well.

**Checklist**:
- [ ] Documentation N/A
- [x] Tests 
- [x] Ready to be merged
- [x] Added myself to contributors table

Thanks for this opportunity to help with this awesome project!! 