### PR TITLE
feat: add review links

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -362,6 +362,15 @@
         "bug",
         "code"
       ]
+    },
+    {
+      "login": "MarceloAlves",
+      "name": "Marcelo Alves",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/216782?v=4",
+      "profile": "https://github.com/marceloalves",
+      "contributions": [
+        "code"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Thanks goes to these wonderful people
   </tr>
   <tr>
     <td align="center"><a href="https://www.destro.me"><img src="https://avatars1.githubusercontent.com/u/7031675?v=4" width="100px;" alt="Fabrizio"/><br /><sub><b>Fabrizio</b></sub></a><br /><a href="https://github.com/all-contributors/all-contributors-cli/issues?q=author%3Adexpota" title="Bug reports">🐛</a> <a href="https://github.com/all-contributors/all-contributors-cli/commits?author=dexpota" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/marceloalves"><img src="https://avatars1.githubusercontent.com/u/216782?v=4" width="100px;" alt="Marcelo Alves"/><br /><sub><b>Marcelo Alves</b></sub></a><br /><a href="https://github.com/all-contributors/all-contributors-cli/commits?author=MarceloAlves" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/src/generate/__tests__/format-contribution-type.js
+++ b/src/generate/__tests__/format-contribution-type.js
@@ -50,6 +50,15 @@ test('return link to issues', () => {
   expect(formatContributionType(options, contributor, 'bug')).toBe(expected)
 })
 
+test('return link to reviews', () => {
+  const contributor = contributors.kentcdodds
+  const {options} = fixtures()
+  const expected =
+    '<a href="https://github.com/all-contributors/all-contributors-cli/pulls?q=is%3Apr+reviewed-by%3Akentcdodds" title="Reviewed Pull Requests">👀</a>'
+
+  expect(formatContributionType(options, contributor, 'review')).toBe(expected)
+})
+
 test('make any symbol into a link if contribution is an object', () => {
   const contributor = contributors.kentcdodds
   const {options} = fixtures()

--- a/src/generate/__tests__/format-contributor.js
+++ b/src/generate/__tests__/format-contributor.js
@@ -20,7 +20,7 @@ test('format a simple contributor', () => {
   const {options} = fixtures()
 
   const expected =
-    '<a href="http://kentcdodds.com"><img src="https://avatars1.githubusercontent.com/u/1500684" width="150px;" alt="Kent C. Dodds"/><br /><sub><b>Kent C. Dodds</b></sub></a><br /><a href="#review-kentcdodds" title="Reviewed Pull Requests">👀</a>'
+    '<a href="http://kentcdodds.com"><img src="https://avatars1.githubusercontent.com/u/1500684" width="150px;" alt="Kent C. Dodds"/><br /><sub><b>Kent C. Dodds</b></sub></a><br /><a href="https://github.com/all-contributors/all-contributors-cli/pulls?q=is%3Apr+reviewed-by%3Akentcdodds" title="Reviewed Pull Requests">👀</a>'
 
   expect(formatContributor(options, contributor)).toBe(expected)
 })
@@ -30,7 +30,7 @@ test('format contributor with complex contribution types', () => {
   const {options} = fixtures()
 
   const expected =
-    '<a href="http://kentcdodds.com"><img src="https://avatars1.githubusercontent.com/u/1500684" width="150px;" alt="Kent C. Dodds"/><br /><sub><b>Kent C. Dodds</b></sub></a><br /><a href="https://github.com/all-contributors/all-contributors-cli/commits?author=kentcdodds" title="Documentation">📖</a> <a href="#review-kentcdodds" title="Reviewed Pull Requests">👀</a> <a href="#question-kentcdodds" title="Answering Questions">💬</a>'
+    '<a href="http://kentcdodds.com"><img src="https://avatars1.githubusercontent.com/u/1500684" width="150px;" alt="Kent C. Dodds"/><br /><sub><b>Kent C. Dodds</b></sub></a><br /><a href="https://github.com/all-contributors/all-contributors-cli/commits?author=kentcdodds" title="Documentation">📖</a> <a href="https://github.com/all-contributors/all-contributors-cli/pulls?q=is%3Apr+reviewed-by%3Akentcdodds" title="Reviewed Pull Requests">👀</a> <a href="#question-kentcdodds" title="Answering Questions">💬</a>'
 
   expect(formatContributor(options, contributor)).toBe(expected)
 })
@@ -53,7 +53,7 @@ test('default image size to 100', () => {
   delete options.imageSize
 
   const expected =
-    '<a href="http://kentcdodds.com"><img src="https://avatars1.githubusercontent.com/u/1500684" width="100px;" alt="Kent C. Dodds"/><br /><sub><b>Kent C. Dodds</b></sub></a><br /><a href="#review-kentcdodds" title="Reviewed Pull Requests">👀</a>'
+    '<a href="http://kentcdodds.com"><img src="https://avatars1.githubusercontent.com/u/1500684" width="100px;" alt="Kent C. Dodds"/><br /><sub><b>Kent C. Dodds</b></sub></a><br /><a href="https://github.com/all-contributors/all-contributors-cli/pulls?q=is%3Apr+reviewed-by%3Akentcdodds" title="Reviewed Pull Requests">👀</a>'
 
   expect(formatContributor(options, contributor)).toBe(expected)
 })

--- a/src/repo/index.js
+++ b/src/repo/index.js
@@ -12,6 +12,8 @@ const SUPPORTED_REPO_TYPES = {
       '<%= options.repoHost || "https://github.com" %>/<%= options.projectOwner %>/<%= options.projectName %>/commits?author=<%= contributor.login %>',
     linkToIssues:
       '<%= options.repoHost || "https://github.com" %>/<%= options.projectOwner %>/<%= options.projectName %>/issues?q=author%3A<%= contributor.login %>',
+    linkToReviews:
+      '<%= options.repoHost || "https://github.com" %>/<%= options.projectOwner %>/<%= options.projectName %>/pulls?q=is%3Apr+reviewed-by%3A<%= contributor.login %>',
     getUserInfo: githubAPI.getUserInfo,
     getContributors: githubAPI.getContributors,
   },
@@ -24,6 +26,8 @@ const SUPPORTED_REPO_TYPES = {
       '<%= options.repoHost || "https://gitlab.com" %>/<%= options.projectOwner %>/<%= options.projectName %>/commits/master',
     linkToIssues:
       '<%= options.repoHost || "https://gitlab.com" %>/<%= options.projectOwner %>/<%= options.projectName %>/issues?author_username=<%= contributor.login %>',
+    linkToReviews:
+      '<%= options.repoHost || "https://gitlab.com" %>/<%= options.projectOwner %>/<%= options.projectName %>/merge_requests?scope=all&state=all&approver_usernames[]=<%= contributor.login %>',
     getUserInfo: gitlabAPI.getUserInfo,
     getContributors: gitlabAPI.getContributors,
   },
@@ -77,6 +81,13 @@ const getLinkToIssues = function(repoType) {
   return null
 }
 
+const getLinkToReviews = function(repoType) {
+  if (repoType in SUPPORTED_REPO_TYPES) {
+    return SUPPORTED_REPO_TYPES[repoType].linkToReviews
+  }
+  return null
+}
+
 const getUserInfo = function(username, repoType, repoHost) {
   if (repoType in SUPPORTED_REPO_TYPES) {
     return SUPPORTED_REPO_TYPES[repoType].getUserInfo(
@@ -107,6 +118,7 @@ module.exports = {
   getTypeName,
   getLinkToCommits,
   getLinkToIssues,
+  getLinkToReviews,
   getUserInfo,
   getContributors,
 }

--- a/src/util/contribution-types.js
+++ b/src/util/contribution-types.js
@@ -81,6 +81,7 @@ const defaultTypes = function(repoType) {
     review: {
       symbol: '👀',
       description: 'Reviewed Pull Requests',
+      link: repo.getLinkToReviews(repoType),
     },
     security: {
       symbol: '🛡️',


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: Adding the linking of reviews made by the user

<!-- Why are these changes necessary? -->
**Why**: Noticed that the link was just an anchor `#review-marceloalves` and since search params can be used on both GitHub/GitLab to filter PR's by reviewer, I thought I would add this

<!-- How were these changes implemented? -->
**How**: Followed how `getLinkToIssues` and `getLinkToCommits` were implemented. Added `getLinkToReviews` with URL template + tests

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation - Not quite sure documentation is needed. Looked but nothing stood out
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
