### PR TITLE
feat(alpha-sort): Add a parameter contributorsSortAlphabetically

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -35,6 +35,12 @@ const yargv = yargs
   .boolean('commit')
   .default('files', ['README.md'])
   .default('contributorsPerLine', 7)
+  .option('contributorsSortAlphabetically', {
+    type: 'boolean',
+    default: false,
+    description:
+      'Sort the list of contributors alphabetically in the generated list',
+  })
   .default('contributors', [])
   .default('config', defaultRCFile)
   .config('config', configPath => {

--- a/src/generate/__tests__/index.js
+++ b/src/generate/__tests__/index.js
@@ -60,6 +60,26 @@ test('split contributors into multiples lines when there are too many', () => {
   expect(result).toMatchSnapshot()
 })
 
+test('sorts the list of contributors if contributorsSortAlphabetically=true', () => {
+  const {kentcdodds, bogas04} = contributors
+  const {options, jfmengels, content} = fixtures()
+
+  const resultPreSorted = generate(
+    options,
+    [bogas04, jfmengels, kentcdodds],
+    content,
+  )
+
+  options.contributorsSortAlphabetically = true
+  const resultAutoSorted = generate(
+    options,
+    [jfmengels, kentcdodds, bogas04],
+    content,
+  )
+
+  expect(resultPreSorted).toEqual(resultAutoSorted)
+})
+
 test('not inject anything if there is no tags to inject content in', () => {
   const {kentcdodds} = contributors
   const {options} = fixtures()

--- a/src/generate/index.js
+++ b/src/generate/index.js
@@ -45,6 +45,11 @@ function formatLine(contributors) {
 
 function generateContributorsList(options, contributors) {
   return _.flow(
+    _.sortBy(function(contributor) {
+      if (options.contributorsSortAlphabetically) {
+        return contributor.name
+      }
+    }),
     _.map(function formatEveryContributor(contributor) {
       return formatContributor(options, contributor)
     }),


### PR DESCRIPTION
This parameter allows the user to sort the list of contributors in
alphabetical order of their name.

**What**: This adds a new CLI flag `--contributorsSortAlphabetically`/config option `contributorsSortAlphabetically` that allows you to display the list of contributors in alphabetical order (based on name).

**Why**: This is a feature request that's come up a couple of times, e.g. https://github.com/all-contributors/all-contributors/issues/225

**How**: The order of contributors is preserved in the JSON file. When the list is rendered, check a contributorsSortAlphabetically option (defaulted to false, to preserve existing behaviour) to decide whether to sort the list of contributors before turning into HTML.

Standard TDD: write a test for the new config option, check it fails, edit the code, check the test passes.

For the CLI, I ran it in the root of this repo to see that it would sort in alphabetical order or order-of-being added, depending on what value I passed.

This needs to be added to the docs in https://github.com/all-contributors/all-contributors/blob/master/docs/cli/configuration.md, but I didn't want to do that until I had approval for the feature and the name of the option.

**Checklist**:

- [ ] Documentation
- [x] Tests
- [ ] Ready to be merged
- [ ] Added myself to contributors table