### PR TITLE
fix(repo): pass optionalPrivateToken to recursive calls

### DIFF
--- a/src/repo/github.js
+++ b/src/repo/github.js
@@ -66,9 +66,11 @@ function getContributorsPage(githubUrl, optionalPrivateToken) {
 
       const nextLink = getNextLink(res.headers.link)
       if (nextLink) {
-        return getContributorsPage(nextLink).then(nextContributors => {
-          return contributorsIds.concat(nextContributors)
-        })
+        return getContributorsPage(nextLink, optionalPrivateToken).then(
+          nextContributors => {
+            return contributorsIds.concat(nextContributors)
+          },
+        )
       }
 
       return contributorsIds


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:

Pass token to function that needs it

<!-- Why are these changes necessary? -->
**Why**:

Without it long lists of contributors will error out

![Screen Shot 2020-04-17 at 9 21 01 AM](https://user-images.githubusercontent.com/1192452/79591084-e42aac00-808c-11ea-9f95-716e1515d85f.png)

<!-- Have you done all of these things?  -->
**Checklist**:
- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
