### PR TITLE
fix: make all-contributors output Prettier compliant.

### DIFF
--- a/src/generate/__tests__/__snapshots__/index.js.snap
+++ b/src/generate/__tests__/__snapshots__/index.js.snap
@@ -20,6 +20,7 @@ These people contributed to the project:
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 Thanks a lot everyone!"
@@ -51,6 +52,7 @@ These people contributed to the project:
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 Thanks a lot everyone!"

--- a/src/generate/__tests__/index.js
+++ b/src/generate/__tests__/index.js
@@ -143,6 +143,7 @@ test('inject nothing if there are no contributors', () => {
     '<!-- markdownlint-disable -->',
     '<!-- markdownlint-restore -->',
     '<!-- prettier-ignore-end -->',
+    '',
     '<!-- ALL-CONTRIBUTORS-LIST:END -->',
     '',
     'Thanks a lot everyone!',

--- a/src/generate/index.js
+++ b/src/generate/index.js
@@ -31,7 +31,7 @@ function injectListBetweenTags(newContent) {
       newContent,
       '<!-- markdownlint-restore -->',
       '\n<!-- prettier-ignore-end -->',
-      '\n',
+      '\n\n',
       previousContent.slice(startOfClosingTagIndex),
     ].join('')
   }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
Fixes all-contributors/all-contributors#441 by inserting a newline after the `prettier-ignore-end`.

<!-- Why are these changes necessary? -->
**Why**:

Without this fix, manual changes are required to all-contributors-cli output to ensure prettier check doesn't fail.

<!-- How were these changes implemented? -->
**How**:

Added a single `\n` and updated the tests.

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
