### PR TITLE
fix(github): show the actual error message

### DIFF
--- a/src/repo/__tests__/github.js
+++ b/src/repo/__tests__/github.js
@@ -77,7 +77,7 @@ test('Throw error when non existent username is provided', async () => {
       'https://developer.github.com/v3/users/#get-a-single-user',
   })
   await expect(getUserInfo(username)).rejects.toThrow(
-    `The username ${username} doesn't exist on github.`,
+    `The username ${username} doesn't exist on GitHub.`,
   )
 })
 

--- a/src/repo/__tests__/github.js
+++ b/src/repo/__tests__/github.js
@@ -58,9 +58,7 @@ async function rejects(promise) {
 }
 
 test('handle errors', async () => {
-  nock('https://api.github.com')
-    .get('/users/nodisplayname')
-    .replyWithError(404)
+  nock('https://api.github.com').get('/users/nodisplayname').replyWithError(404)
 
   await rejects(getUserInfo('nodisplayname'))
 })
@@ -73,15 +71,13 @@ test('Throw error when no username is provided', () => {
 
 test('Throw error when non existent username is provided', async () => {
   const username = 'thisusernamedoesntexist'
-  nock('https://api.github.com')
-    .get(`/users/${username}`)
-    .reply(404, {
-      message: 'Not Found',
-      documentation_url:
-        'https://developer.github.com/v3/users/#get-a-single-user',
-    })
+  nock('https://api.github.com').get(`/users/${username}`).reply(404, {
+    message: 'Not Found',
+    documentation_url:
+      'https://developer.github.com/v3/users/#get-a-single-user',
+  })
   await expect(getUserInfo(username)).rejects.toThrow(
-    `Login not found when adding a contributor for username - ${username}.`,
+    `The username ${username} doesn't exist on github.`,
   )
 })
 
@@ -100,27 +96,24 @@ test('Throw error when missing enterprise authentication', async () => {
   )
 })
 
-test('handle github errors', async () => {
-  nock('https://api.github.com')
-    .get('/users/nodisplayname')
-    .reply(200, {
-      message:
-        "API rate limit exceeded for 0.0.0.0. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)",
-      documentation_url: 'https://developer.github.com/v3/#rate-limiting',
-    })
+test('handle API rate github errors', async () => {
+  const githubErrorMessage =
+    "API rate limit exceeded for 0.0.0.0. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details."
+  nock('https://api.github.com').get('/users/nodisplayname').reply(200, {
+    message: githubErrorMessage,
+    documentation_url: 'https://developer.github.com/v3/#rate-limiting',
+  })
 
-  await rejects(getUserInfo('nodisplayname'))
+  await expect(getUserInfo('nodisplayname')).rejects.toThrow(githubErrorMessage)
 })
 
 test('fill in the name when null is returned', async () => {
-  nock('https://api.github.com')
-    .get('/users/nodisplayname')
-    .reply(200, {
-      login: 'nodisplayname',
-      name: null,
-      avatar_url: 'https://avatars2.githubusercontent.com/u/3869412?v=3&s=400',
-      html_url: 'https://github.com/nodisplayname',
-    })
+  nock('https://api.github.com').get('/users/nodisplayname').reply(200, {
+    login: 'nodisplayname',
+    name: null,
+    avatar_url: 'https://avatars2.githubusercontent.com/u/3869412?v=3&s=400',
+    html_url: 'https://github.com/nodisplayname',
+  })
 
   const info = await getUserInfo('nodisplayname')
   expect(info.name).toBe('nodisplayname')
@@ -161,28 +154,24 @@ test('attaches no token when not supplied', async () => {
 })
 
 test('fill in the name when an empty string is returned', async () => {
-  nock('https://api.github.com')
-    .get('/users/nodisplayname')
-    .reply(200, {
-      login: 'nodisplayname',
-      name: '',
-      avatar_url: 'https://avatars2.githubusercontent.com/u/3869412?v=3&s=400',
-      html_url: 'https://github.com/nodisplayname',
-    })
+  nock('https://api.github.com').get('/users/nodisplayname').reply(200, {
+    login: 'nodisplayname',
+    name: '',
+    avatar_url: 'https://avatars2.githubusercontent.com/u/3869412?v=3&s=400',
+    html_url: 'https://github.com/nodisplayname',
+  })
 
   const info = await getUserInfo('nodisplayname')
   expect(info.name).toBe('nodisplayname')
 })
 
 test('append http when no absolute link is provided', async () => {
-  nock('https://api.github.com')
-    .get('/users/nodisplayname')
-    .reply(200, {
-      login: 'nodisplayname',
-      name: '',
-      avatar_url: 'https://avatars2.githubusercontent.com/u/3869412?v=3&s=400',
-      html_url: 'www.github.com/nodisplayname',
-    })
+  nock('https://api.github.com').get('/users/nodisplayname').reply(200, {
+    login: 'nodisplayname',
+    name: '',
+    avatar_url: 'https://avatars2.githubusercontent.com/u/3869412?v=3&s=400',
+    html_url: 'www.github.com/nodisplayname',
+  })
 
   const info = await getUserInfo('nodisplayname')
   expect(info.profile).toBe('http://www.github.com/nodisplayname')

--- a/src/repo/github.js
+++ b/src/repo/github.js
@@ -105,7 +105,7 @@ const getUserInfo = function (username, hostname, optionalPrivateToken) {
         if (body.message.toLowerCase().includes('api rate limit exceeded')) {
           throw new Error(body.message)
         } else {
-          throw new Error(`The username ${username} doesn't exist on github.`)
+          throw new Error(`The username ${username} doesn't exist on GitHub.`)
         }
       }
 

--- a/src/repo/github.js
+++ b/src/repo/github.js
@@ -102,9 +102,11 @@ const getUserInfo = function (username, hostname, optionalPrivateToken) {
 
       // Github throwing specific errors as 200...
       if (!profile && body.message) {
-        throw new Error(
-          `Login not found when adding a contributor for username - ${username}.`,
-        )
+        if (body.message.toLowerCase().includes('api rate limit exceeded')) {
+          throw new Error(body.message)
+        } else {
+          throw new Error(`The username ${username} doesn't exist on github.`)
+        }
       }
 
       profile = parseHttpUrl(profile)


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**:
When getting the "API rate limit exceeded" error, this fix shows the original message. Plus it also fixes the current confusing "no login" error message and changes it to "Github username not found".

Fixes #284 

<!-- Why are these changes necessary? -->
**Why**:
See #284 

<!-- How were these changes implemented? -->
**How**:
By the magic of code 😛

Changes done to `github.js` and its test

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->