### PR TITLE
refactor: return a Promise instead of relying on callback parameter

### DIFF
--- a/src/init/__tests__/add-contributors-list.js
+++ b/src/init/__tests__/add-contributors-list.js
@@ -30,20 +30,24 @@ test('create contributors section if content is empty', () => {
   expect(result).toMatchSnapshot()
 })
 
-test('README exists', done => {
-  const file = 'README.md'
-  ensureFileExists(file)
-    .then(data => expect(data).toStrictEqual(file))
-    .then(_ => done())
+test('README exists', () => {
+  return new Promise(done => {
+    const file = 'README.md'
+    ensureFileExists(file)
+      .then(data => expect(data).toStrictEqual(file))
+      .then(_ => done())
+  })
 })
 
-test("LOREM doesn't exists", done => {
-  const file = 'LOREM.md'
-  ensureFileExists(file).then(data => {
-    expect(data).toStrictEqual(file)
-    return unlink(file, err => {
-      if (err) throw err
-      done()
+test("LOREM doesn't exists", () => {
+  return new Promise(done => {
+    const file = 'LOREM.md'
+    ensureFileExists(file).then(data => {
+      expect(data).toStrictEqual(file)
+      return unlink(file, err => {
+        if (err) throw err
+        done()
+      })
     })
   })
 })


### PR DESCRIPTION
**What**:

Fix new ESlint issues on master branch.

**Why**:

The ESlint rule `jest/no-done-callback` was added  [here](https://github.com/kentcdodds/eslint-config-kentcdodds/commit/d41a11fd7436ce7b4b662daea53d6f3cdf5aa720). Because the package versions are not pinned, the current master branch is failing, and so are all [new PRs](https://github.com/all-contributors/all-contributors-cli/pull/288).

<!-- How were these changes implemented? -->
**How**:

Fix new ESlint warning by turning callbacks into promises.

**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table

<!-- feel free to add additional comments -->
