### PR TITLE
feat(contribution-types): add research contribution type

### DIFF
--- a/src/util/contribution-types.js
+++ b/src/util/contribution-types.js
@@ -95,7 +95,7 @@ const defaultTypes = function(repoType) {
       description: 'Answering Questions',
     },
     research: {
-      symbol: ':microscope:',
+      symbol: '🔬',
       description: 'Research',
     },
     review: {

--- a/src/util/contribution-types.js
+++ b/src/util/contribution-types.js
@@ -99,6 +99,10 @@ const defaultTypes = function(repoType) {
       description: 'Reviewed Pull Requests',
       link: repo.getLinkToReviews(repoType),
     },
+    question: {
+      symbol: ':microscope:',
+      description: 'Research',
+    },
     security: {
       symbol: '🛡️',
       description: 'Security',

--- a/src/util/contribution-types.js
+++ b/src/util/contribution-types.js
@@ -94,14 +94,14 @@ const defaultTypes = function(repoType) {
       symbol: '💬',
       description: 'Answering Questions',
     },
+    research: {
+      symbol: ':microscope:',
+      description: 'Research',
+    },
     review: {
       symbol: '👀',
       description: 'Reviewed Pull Requests',
       link: repo.getLinkToReviews(repoType),
-    },
-    question: {
-      symbol: ':microscope:',
-      description: 'Research',
     },
     security: {
       symbol: '🛡️',


### PR DESCRIPTION
**What**:
Add a research contribution type with microscope emoji, for people doing literature review, code
prototyping or any other research-related activity.

Part 2/3 of #446

**Why**:
For open science projects or dev projects with a research component, people carrying out research tasks cannot always be acknowledged with the existing types.

<!-- How were these changes implemented? -->
Adding the type description and emoji to the list of types available to the CLI tool.

**Checklist**:
- [x] Documentation
- [ ] Tests
- [ ] Ready to be merged
- [ ] Added myself to contributors table


I'm not really familiar with npm so I'm not sure how to install my modified version of the cli tool to test it. Any help?
Bot PR following.