### PR TITLE
feat: add namespaced token

### DIFF
--- a/src/repo/index.js
+++ b/src/repo/index.js
@@ -1,7 +1,7 @@
 const githubAPI = require('./github')
 const gitlabAPI = require('./gitlab')
 
-const privateToken = (process.env && (process.env.ALL_CONTRIBUTORS_PRIVATE_TOKEN || (process.env.PRIVATE_TOKEN))) || ''
+const privateToken = (process.env && (process.env.ALL_CONTRIBUTORS_PRIVATE_TOKEN || process.env.PRIVATE_TOKEN)) || ''
 const SUPPORTED_REPO_TYPES = {
   github: {
     value: 'github',

--- a/src/repo/index.js
+++ b/src/repo/index.js
@@ -1,7 +1,7 @@
 const githubAPI = require('./github')
 const gitlabAPI = require('./gitlab')
 
-const privateToken = (process.env && process.env.PRIVATE_TOKEN) || ''
+const privateToken = (process.env && (process.env.ALL_CONTRIBUTORS_PRIVATE_TOKEN || (process.env.PRIVATE_TOKEN))) || ''
 const SUPPORTED_REPO_TYPES = {
   github: {
     value: 'github',

--- a/src/repo/index.js
+++ b/src/repo/index.js
@@ -1,7 +1,7 @@
 const githubAPI = require('./github')
 const gitlabAPI = require('./gitlab')
 
-const privateToken = (process.env && (process.env.ALL_CONTRIBUTORS_PRIVATE_TOKEN || (process.env.PRIVATE_TOKEN))) || ''
+const privateToken = (process.env && (process.env.ALL_CONTRIBUTORS_PRIVATE_TOKEN || (process.env.PRIVATE_TOKEN))) || ''
 const SUPPORTED_REPO_TYPES = {
   github: {
     value: 'github',


### PR DESCRIPTION
This commit adds the possibility to specify the private token via the
ALL_CONTRIBUTORS_PRIVATE_TOKEN environment variable. If the environment
variable is not set it will fall back to the previous behavior and check
for PRIVATE_TOKEN instead.

Closes #294